### PR TITLE
ci: remove SonarSource configuration from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: SonarSource/sonarcloud-github-action@v5
-        if: ${{ github.event_name != 'pull_request' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly


### PR DESCRIPTION
Remove SonarCloud GitHub Action integration and associated secrets from the lint job to simplify the CI pipeline.